### PR TITLE
Adapt crit installation to Python 3.12

### DIFF
--- a/crit/pyproject.toml
+++ b/crit/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools"]

--- a/crit/setup.py
+++ b/crit/setup.py
@@ -1,0 +1,29 @@
+import os
+from setuptools import setup, find_packages
+
+
+def get_version():
+    version = '0.0.1'
+    env = os.environ
+    if 'CRIU_VERSION_MAJOR' in env and 'CRIU_VERSION_MINOR' in env:
+        version = '{}.{}'.format(
+            env['CRIU_VERSION_MAJOR'],
+            env['CRIU_VERSION_MINOR']
+        )
+        if 'CRIU_VERSION_SUBLEVEL' in env and env['CRIU_VERSION_SUBLEVEL']:
+            version += '.' + env['CRIU_VERSION_SUBLEVEL']
+    return version
+
+
+setup(
+    name='crit',
+    version=get_version(),
+    description='CRiu Image Tool',
+    author='CRIU team',
+    author_email='criu@openvz.org',
+    license='GPLv2',
+    url='https://github.com/canonical/crac-criu',
+    packages=find_packages('.'),
+    scripts=['crit'],
+    install_requires=[],
+)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,10 +2,6 @@ CRIU_SO			:= libcriu.so
 CRIU_A			:= libcriu.a
 UAPI_HEADERS		:= lib/c/criu.h images/rpc.proto images/rpc.pb-c.h criu/include/version.h
 
-#
-# File to keep track of files installed by setup.py
-CRIT_SETUP_FILES	:= lib/.crit-setup.files
-
 all-y	+= lib-c lib-a lib-py
 
 #
@@ -58,8 +54,10 @@ install: lib-c lib-a lib-py crit/crit lib/c/criu.pc.in
 	$(Q) mkdir -p $(DESTDIR)$(LIBDIR)/pkgconfig
 	$(Q) sed -e 's,@version@,$(CRIU_VERSION),' -e 's,@libdir@,$(LIBDIR),' -e 's,@includedir@,$(dir $(INCLUDEDIR)/criu/),' lib/c/criu.pc.in > lib/c/criu.pc
 	$(Q) install -m 644 lib/c/criu.pc $(DESTDIR)$(LIBDIR)/pkgconfig
+ifeq ($(PYTHON),python3)
 	$(E) "  INSTALL " crit
-	$(Q) $(PYTHON) scripts/crit-setup.py install --prefix=$(DESTDIR)$(PREFIX) --record $(CRIT_SETUP_FILES)
+	$(Q) $(PYTHON) -m pip install --no-build-isolation --no-index --no-deps --progress-bar off --upgrade --force-reinstall --prefix=$(DESTDIR)$(PREFIX) ./crit
+endif
 .PHONY: install
 
 uninstall:
@@ -71,6 +69,8 @@ uninstall:
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/criu/,$(notdir $(UAPI_HEADERS)))
 	$(E) " UNINSTALL" pkgconfig/criu.pc
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/pkgconfig/,criu.pc)
+ifeq ($(PYTHON),python3)
 	$(E) " UNINSTALL" crit
-	$(Q) while read -r file; do $(RM) "$$file"; done < $(CRIT_SETUP_FILES)
+	$(Q) $(PYTHON) ./scripts/uninstall_module.py --prefix=$(DESTDIR)$(PREFIX) crit
+endif
 .PHONY: uninstall

--- a/scripts/uninstall_module.py
+++ b/scripts/uninstall_module.py
@@ -1,0 +1,65 @@
+#!/usr/bin/python3
+"""
+`pip uninstall` doesn't support `--prefix`.
+https://github.com/pypa/pip/issues/11213
+"""
+import argparse
+import os
+import shutil
+import site
+import subprocess
+import sys
+
+import importlib_metadata
+
+
+def add_site_dir(prefix: str):
+    """
+    Add site directory with prefix to sys.path and update PYTHONPATH.
+    """
+    # If prefix is used, we need to make sure that we
+    # do not uninstall other packages from the system paths.
+    sys.path = []
+    site.PREFIXES = [prefix]
+    pkgs = site.getsitepackages()
+    for path in pkgs:
+        site.addsitedir(path)
+        if 'dist-packages' in path:
+            # Ubuntu / Debian might use both dist- and site- packages.
+            site.addsitedir(path.replace('dist-packages', 'site-packages'))
+    os.environ['PYTHONPATH'] = os.pathsep.join(sys.path)
+
+
+def uninstall_module(package_name: str, prefix=None):
+    """
+    Enable support for '--prefix' with 'pip uninstall'.
+    """
+    dist_info_path = None
+    if prefix:
+        add_site_dir(prefix)
+        try:
+            dist_info_path = str(importlib_metadata.distribution(package_name)._path)
+        except importlib_metadata.PackageNotFoundError:
+            print(f"Skipping {package_name} as it is not installed.")
+            sys.exit(0)
+
+    command = [sys.executable, '-m', 'pip', 'uninstall', '-y', package_name]
+    try:
+        subprocess.check_call(command, env=os.environ)
+        if dist_info_path and os.path.isdir(dist_info_path):
+            # .dist-info files are not cleaned up when the package
+            # has been installed with --prefix.
+            # https://github.com/pypa/pip/issues/5573
+            shutil.rmtree(dist_info_path)
+            if 'dist-packages' in dist_info_path:
+                shutil.rmtree(dist_info_path.replace('dist-packages', 'site-packages'))
+    except subprocess.CalledProcessError as err:
+        print(f'Error uninstalling package {package_name}: {err}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('module_name', help='The name of the module to uninstall')
+    parser.add_argument('--prefix', help='The prefix where the module was installed')
+    args = parser.parse_args()
+    uninstall_module(args.module_name, args.prefix)


### PR DESCRIPTION
Backported from upstream criu:
https://github.com/checkpoint-restore/criu/commit/7f0f07599a680258092a7790fb3046856f486f2f

also combined with this change:
https://github.com/rst0git/criu-deb-packages/commit/80ddb47974f541b99a7afc3e4e226e850648f27d

both authored by Radostin Stoyanov <rstoyanov@fedoraproject.org>

This solution by Alexander Mikhalitsyn <aleksandr.mikhalitsyn@canonical.com> was posted against https://bugs.launchpad.net/bugs/2066148.

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/checkpoint-restore/criu/blob/criu-dev/CONTRIBUTING.md

In short you need to:

- Describe What you do and How you do it;
- Separate each logical change into a separate commit;
- Add a "Signed-off-by:" line identifying that you certify your work with DCO;
- If you fix some specific bug or commit, please add "Fixes: ..." line;
- Review fixes should be made by amending the original commits. For example:
  a) fix the code (e.g. this fixes commit with hash aaa1111)
  b) git commit -a --fixup aaa1111
  c) git rebase --interactive --autosquash aaa1111^
- Pull request integration tests should generally be passing;
- If you change something non-obvious, please consider adding a ZDTM test for it;

-->
