### PR TITLE
Modify installation to co-exist with upstream criu

### DIFF
--- a/Makefile.compel
+++ b/Makefile.compel
@@ -24,8 +24,8 @@ compel-deps		+= $(CONFIG_HEADER)
 compel-deps		+= include/common/asm
 compel-plugins		+= compel/plugins/std.lib.a compel/plugins/fds.lib.a
 
-LIBCOMPEL_SO		:= libcompel.so
-LIBCOMPEL_A		:= libcompel.a
+LIBCOMPEL_SO		:= libcompel-crac.so
+LIBCOMPEL_A		:= libcompel-crac.a
 export LIBCOMPEL_SO LIBCOMPEL_A
 
 #

--- a/compel/Makefile
+++ b/compel/Makefile
@@ -54,7 +54,7 @@ cleanup-y		+= compel/libcompel.so
 install: compel/compel compel/$(LIBCOMPEL_SO) compel/$(LIBCOMPEL_A)
 	$(E) "  INSTALL " compel
 	$(Q) mkdir -p $(DESTDIR)$(BINDIR)
-	$(Q) install -m 755 compel/compel $(DESTDIR)$(BINDIR)
+	$(Q) install -m 755 compel/compel $(DESTDIR)$(BINDIR)/compel-crac
 	$(E) "  INSTALL " $(LIBCOMPEL_SO)
 	$(Q) mkdir -p $(DESTDIR)$(LIBDIR)
 	$(Q) install -m 0644 compel/$(LIBCOMPEL_SO) $(DESTDIR)$(LIBDIR)
@@ -64,16 +64,16 @@ install: compel/compel compel/$(LIBCOMPEL_SO) compel/$(LIBCOMPEL_A)
 	$(E) "  INSTALL " $(LIBCOMPEL_A)
 	$(Q) install -m 0644 compel/$(LIBCOMPEL_A) $(DESTDIR)$(LIBDIR)
 	$(E) "  INSTALL " compel uapi
-	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/compel/asm
-	$(Q) cp compel/include/uapi/*.h $(DESTDIR)$(INCLUDEDIR)/compel/
-	$(Q) cp compel/include/uapi/asm/*.h $(DESTDIR)$(INCLUDEDIR)/compel/asm/
-	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/compel/common/asm
-	$(Q) cp include/common/compiler.h $(DESTDIR)$(INCLUDEDIR)/compel/common/
+	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/asm
+	$(Q) cp compel/include/uapi/*.h $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/
+	$(Q) cp compel/include/uapi/asm/*.h $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/asm/
+	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/common/asm
+	$(Q) cp include/common/compiler.h $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/common/
 .PHONY: install
 
 uninstall:
 	$(E) " UNINSTALL" compel
-	$(Q) $(RM) $(addprefix $(DESTDIR)$(BINDIR)/,compel)
+	$(Q) $(RM) $(addprefix $(DESTDIR)$(BINDIR)/,compel-crac)
 	$(E) " UNINSTALL" $(LIBCOMPEL_SO)
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/,$(LIBCOMPEL_SO))
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/,$(LIBCOMPEL_SO).$(COMPEL_SO_VERSION_MAJOR))
@@ -81,5 +81,5 @@ uninstall:
 	$(E) " UNINSTALL" $(LIBCOMPEL_A)
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/,$(LIBCOMPEL_A))
 	$(E) " UNINSTALL" compel uapi
-	$(Q) $(RM) -rf $(addprefix $(DESTDIR)$(INCLUDEDIR)/,compel/*)
+	$(Q) $(RM) -rf $(addprefix $(DESTDIR)$(INCLUDEDIR)/,crac-criu/compel/*)
 .PHONY: uninstall

--- a/compel/plugins/Makefile
+++ b/compel/plugins/Makefile
@@ -101,10 +101,10 @@ install: compel/plugins/std.lib.a compel/plugins/fds.lib.a
 	$(Q) mkdir -p $(DESTDIR)$(LIBEXECDIR)/compel/scripts
 	$(Q) install -m 0644 compel/arch/$(ARCH)/scripts/compel-pack.lds.S $(DESTDIR)$(LIBEXECDIR)/compel/scripts
 	$(E) "  INSTALL " compel plugins uapi
-	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/compel/plugins/std/asm
-	$(Q) cp -fL compel/plugins/include/uapi/*.h $(DESTDIR)$(INCLUDEDIR)/compel/plugins/
-	$(Q) cp -fL compel/plugins/include/uapi/std/*.h $(DESTDIR)$(INCLUDEDIR)/compel/plugins/std/
-	$(Q) cp -fL compel/plugins/include/uapi/std/asm/*.h $(DESTDIR)$(INCLUDEDIR)/compel/plugins/std/asm/
+	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/plugins/std/asm
+	$(Q) cp -fL compel/plugins/include/uapi/*.h $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/plugins/
+	$(Q) cp -fL compel/plugins/include/uapi/std/*.h $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/plugins/std/
+	$(Q) cp -fL compel/plugins/include/uapi/std/asm/*.h $(DESTDIR)$(INCLUDEDIR)/crac-criu/compel/plugins/std/asm/
 .PHONY: install
 
 uninstall:
@@ -112,5 +112,5 @@ uninstall:
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBEXECDIR)/compel/,*.lib.a)
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBEXECDIR)/compel/scripts/,compel-pack.lds.S)
 	$(E) " UNINSTALL" compel and plugins uapi
-	$(Q) $(RM) -rf $(addprefix $(DESTDIR)$(INCLUDEDIR)/,compel/plugins)
+	$(Q) $(RM) -rf $(addprefix $(DESTDIR)$(INCLUDEDIR)/,crac-criu/compel/plugins)
 .PHONY: uninstall

--- a/criu/Makefile
+++ b/criu/Makefile
@@ -140,22 +140,22 @@ UAPI_HEADERS += criu/include/criu-log.h
 install: $(obj)/criu
 	$(E) "  INSTALL " $(obj)/criu
 	$(Q) mkdir -p $(DESTDIR)$(SBINDIR)
-	$(Q) install -m 755 $(obj)/criu $(DESTDIR)$(SBINDIR)
-	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/criu/
-	$(Q) install -m 644 $(UAPI_HEADERS) $(DESTDIR)$(INCLUDEDIR)/criu/
+	$(Q) install -m 755 $(obj)/criu $(DESTDIR)$(SBINDIR)/criu-crac
+	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/
+	$(Q) install -m 644 $(UAPI_HEADERS) $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/
 	$(Q) mkdir -p $(DESTDIR)$(LIBEXECDIR)/criu/scripts
 	$(Q) install -m 755 scripts/systemd-autofs-restart.sh $(DESTDIR)$(LIBEXECDIR)/criu/scripts
 ifeq ($(PYTHON),python3)
 	$(E) "  INSTALL " scripts/criu-ns
-	$(Q) install -m 755 scripts/criu-ns $(DESTDIR)$(SBINDIR)
+	$(Q) install -m 755 scripts/criu-ns $(DESTDIR)$(SBINDIR)/criu-ns-crac
 endif
 .PHONY: install
 
 uninstall:
 	$(E) " UNINSTALL" criu
-	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,criu)
-	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,criu-ns)
-	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/criu/,$(notdir $(UAPI_HEADERS)))
+	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,criu-crac)
+	$(Q) $(RM) $(addprefix $(DESTDIR)$(SBINDIR)/,criu-ns-crac)
+	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/,$(notdir $(UAPI_HEADERS)))
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBEXECDIR)/criu/scripts/,systemd-autofs-restart.sh)
 .PHONY: uninstall
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,5 @@
-CRIU_SO			:= libcriu.so
-CRIU_A			:= libcriu.a
+CRIU_SO			:= libcriu-crac.so
+CRIU_A			:= libcriu-crac.a
 UAPI_HEADERS		:= lib/c/criu.h images/rpc.proto images/rpc.pb-c.h criu/include/version.h
 
 all-y	+= lib-c lib-a lib-py
@@ -48,12 +48,12 @@ install: lib-c lib-a lib-py crit/crit lib/c/criu.pc.in
 	$(Q) ln -fns $(CRIU_SO).$(CRIU_SO_VERSION_MAJOR).$(CRIU_SO_VERSION_MINOR) $(DESTDIR)$(LIBDIR)/$(CRIU_SO).$(CRIU_SO_VERSION_MAJOR)
 	$(Q) ln -fns $(CRIU_SO).$(CRIU_SO_VERSION_MAJOR).$(CRIU_SO_VERSION_MINOR) $(DESTDIR)$(LIBDIR)/$(CRIU_SO)
 	$(Q) install -m 755 lib/c/$(CRIU_A) $(DESTDIR)$(LIBDIR)/$(CRIU_A)
-	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/criu/
-	$(Q) install -m 644 $(UAPI_HEADERS) $(DESTDIR)$(INCLUDEDIR)/criu/
+	$(Q) mkdir -p $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/
+	$(Q) install -m 644 $(UAPI_HEADERS) $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/
 	$(E) "  INSTALL " pkgconfig/criu.pc
 	$(Q) mkdir -p $(DESTDIR)$(LIBDIR)/pkgconfig
-	$(Q) sed -e 's,@version@,$(CRIU_VERSION),' -e 's,@libdir@,$(LIBDIR),' -e 's,@includedir@,$(dir $(INCLUDEDIR)/criu/),' lib/c/criu.pc.in > lib/c/criu.pc
-	$(Q) install -m 644 lib/c/criu.pc $(DESTDIR)$(LIBDIR)/pkgconfig
+	$(Q) sed -e 's,@version@,$(CRIU_VERSION),' -e 's,@libdir@,$(LIBDIR),' -e 's,@includedir@,$(dir $(INCLUDEDIR)/crac-criu/criu/),' lib/c/criu.pc.in > lib/c/criu.pc
+	$(Q) install -m 644 lib/c/criu.pc $(DESTDIR)$(LIBDIR)/pkgconfig/crac-criu.pc
 ifeq ($(PYTHON),python3)
 	$(E) "  INSTALL " crit
 	$(Q) $(PYTHON) -m pip install --no-build-isolation --no-index --no-deps --progress-bar off --upgrade --force-reinstall --prefix=$(DESTDIR)$(PREFIX) ./crit
@@ -66,9 +66,9 @@ uninstall:
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/,$(CRIU_SO))
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/,$(CRIU_A))
 	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/,$(CRIU_SO).$(CRIU_SO_VERSION_MAJOR).$(CRIU_SO_VERSION_MINOR))
-	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/criu/,$(notdir $(UAPI_HEADERS)))
-	$(E) " UNINSTALL" pkgconfig/criu.pc
-	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/pkgconfig/,criu.pc)
+	$(Q) $(RM) $(addprefix $(DESTDIR)$(INCLUDEDIR)/crac-criu/criu/,$(notdir $(UAPI_HEADERS)))
+	$(E) " UNINSTALL" pkgconfig/crac-criu.pc
+	$(Q) $(RM) $(addprefix $(DESTDIR)$(LIBDIR)/pkgconfig/,crac-criu.pc)
 ifeq ($(PYTHON),python3)
 	$(E) " UNINSTALL" crit
 	$(Q) $(PYTHON) ./scripts/uninstall_module.py --prefix=$(DESTDIR)$(PREFIX) crit

--- a/lib/c/criu.pc.in
+++ b/lib/c/criu.pc.in
@@ -1,8 +1,8 @@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: CRIU for OpenJDK CRaC
+Name: crac-criu
 Description: CRIU adapted for the OpenJDK CRaC project 
 Version: @version@
-Libs: -L${libdir} -lcriu
+Libs: -L${libdir} -lcriu-crac
 Cflags: -I${includedir}

--- a/lib/c/criu.pc.in
+++ b/lib/c/criu.pc.in
@@ -1,8 +1,8 @@
 libdir=@libdir@
 includedir=@includedir@
 
-Name: CRIU
-Description: RPC library for userspace checkpoint and restore
+Name: CRIU for OpenJDK CRaC
+Description: CRIU adapted for the OpenJDK CRaC project 
 Version: @version@
 Libs: -L${libdir} -lcriu
 Cflags: -I${includedir}


### PR DESCRIPTION
This commit tries distinguish a crac-criu installation from an upstream criu installation. The one part where this gets challenging is the pycriu Python module. Renaming it does not sound like a good workaround. Hence the crit/pycriu names have been retained and might cause a conflict with those installed by upstream criu. However, for now, we might not anticipate users of OpenJDK CRaC wanting to use the Python bindings. So, installation of pycriu may be disabled during Debian packaging this repo.
